### PR TITLE
Update manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,5 @@ applications:
   memory: 512M
   instances: 1
   random-route: true
+  buildpacks:
+    - https://github.com/cloudfoundry/nodejs-buildpack


### PR DESCRIPTION
explicitly stated the nodejs buildpack for reasons of more clarity and keeping in line with the updated syntax for using buildpacks in CF