### PR TITLE
Switch instance index ENV from legacy to current

### DIFF
--- a/app/vcap_application.js
+++ b/app/vcap_application.js
@@ -23,7 +23,7 @@ module.exports = {
 
   get_app_index: function () {
     if ( process.env.INSTANCE_INDEX) {
-      var app_index = process.env.INSTANCE_INDEX
+      var app_index = process.env.CF_INSTANCE_INDEX
       return app_index
     }
   },

--- a/app/vcap_application.js
+++ b/app/vcap_application.js
@@ -22,7 +22,7 @@ module.exports = {
   },
 
   get_app_index: function () {
-    if ( process.env.INSTANCE_INDEX) {
+    if ( process.env.CF_INSTANCE_INDEX) {
       var app_index = process.env.CF_INSTANCE_INDEX
       return app_index
     }


### PR DESCRIPTION
It's called `CF_INSTANCE_INDEX` nowadays: https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#CF-INSTANCE-INDEX
This makes a difference when installing this on cf-for-k8s, as it doesn't provide the legacy `INSTANCE_INDEX` variable anymore.